### PR TITLE
Run kakship asynchronously

### DIFF
--- a/rc/kakship.kak
+++ b/rc/kakship.kak
@@ -12,13 +12,14 @@ kakship-enable %{
 provide-module kakship %{
 
 define-command -hidden -docstring "set modeline using kakship" starship-modeline %{
-	evaluate-commands %sh{
+	nop %sh{ {
 		# trigger var export: kak_buffile, kak_session, kak_client, kak_config, kak_cursor_line, kak_buf_line_count
 		#                     kak_opt_lsp_diagnostic_error_count, kak_opt_lsp_diagnostic_warning_count
 		dir=${kak_buffile%/*}
 		[ "$dir" != "$kak_buffile" ] && cd $dir
-		printf 'set-option window modelinefmt %%{%s}' "$(kakship prompt)"
-	}
+		printf "eval -client '%s' 'set-option window modelinefmt %%{%s}'" \
+			"$kak_client" "$(kakship prompt)" | kak -p ${kak_session}
+	} > /dev/null 2>&1 < /dev/null & }
 }
 
 define-command -docstring "disable starship modeline" kakship-disable %{


### PR DESCRIPTION
When working in a large project like Chromium, starship git modules
like git_status can take a long time (I've experienced up to a second
of delay). Previously, the kakship call was run synchronously, which
blocks the editor while the command is running and prevents user
input. This change makes the kakship call async so movement is still
smooth while the prompt is being created.